### PR TITLE
Handle a None decorator in pyramid views

### DIFF
--- a/appenlight_client/ext/pyramid_tween.py
+++ b/appenlight_client/ext/pyramid_tween.py
@@ -81,7 +81,7 @@ def wrap_pyramid_view_name(appenlight_callable):
 def wrap_view_config(appenlight_callable):
     @wraps(appenlight_callable)
     def wrapper(*args, **kwargs):
-        if not 'decorator' in kwargs:
+        if kwargs.get('decorator') is None:
             if can_append_decorator:
                 kwargs['decorator'] = wrap_pyramid_view_name
         else:


### PR DESCRIPTION
This is needed with pyramid 1.5a3. Without this change I get the following error on app startup:

```
  File "/Users/wichert/Library/buildout/eggs/pyramid-1.5a3-py2.7.egg/pyramid/config/views.py", line 1636, in add_forbidden_view
    return self.add_view(**settings)
  File "/Users/wichert/Library/buildout/eggs/appenlight_client-0.6-py2.7.egg/appenlight_client/ext/pyramid_tween.py", line 89, in wrapper
    kwargs['decorator'].append(wrap_pyramid_view_name)
AttributeError: 'NoneType' object has no attribute 'append'
```

Poking around with pdb shows the following kwargs at that point:

```
-> if not 'decorator' in kwargs:
(Pdb) pp kwargs
{'accept': None,
 'attr': None,
 'containment': None,
 'context': <class 'pyramid.httpexceptions.HTTPForbidden'>,
 'custom_predicates': (),
 'decorator': None,
 'header': None,
 'mapper': None,
 'match_param': None,
 'path_info': None,
 'permission': '__no_permission_required__',
 'renderer': 'json',
 'request_method': None,
 'request_param': None,
 'request_type': None,
 'route_name': None,
 'view': <function forbidden at 0x101f3cc80>,
 'wrapper': None,
 'xhr': None}
```
