### PR TITLE
Merge settings with file configuration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 CHANGELOG:
 ==========
 
+2014-01-07 Config file handling
+           Allow combining of a separate config file and direct settings.
+
 2014-01-05 Minor bugfixes
 
 2013-12-23 Minor bugfixes

--- a/appenlight_client/client.py
+++ b/appenlight_client/client.py
@@ -575,7 +575,7 @@ def get_config(config=None, path_to_config=None, section_name='appenlight'):
     if not api_key:
         api_key = os.environ.get('ERRORMATOR_KEY')
     if path_to_config:
-        config = {}
+        file_config = {}
         if not os.path.exists(path_to_config):
             logging.warning("Couldn't locate %s " % path_to_config)
             return config
@@ -583,9 +583,10 @@ def get_config(config=None, path_to_config=None, section_name='appenlight'):
             parser = ConfigParser.SafeConfigParser()
             parser.readfp(f)
             try:
-                config = dict(parser.items(section_name))
+                file_config = dict(parser.items(section_name))
             except ConfigParser.NoSectionError as exc:
                 logging.warning('No section name called %s in file' % section_name)
+            config.update(file_config)
             if not config.get('api_key') and api_key:
                 config['appenlight.api_key'] = api_key
     if not config.get('api_key') and api_key:


### PR DESCRIPTION
This makes it possible to combine settings in a configuration file with settings from a PasteDeploy .ini-file or in-Python defaults. Settings in the configuration file will override others.

Example usages:

``` python
# app.py
app = config.make_wsgi_app()
return make_appenlight_middleware(app, {'appenlight.logging': True})
```

``` config
[app:main]
appenlight.api_key = 123456
appenlight.config_path = %(here)s/etc/appenlight.ini
```
