### PR TITLE
Stack should be cleared first before adding it's nodes as a parents.

### DIFF
--- a/appenlight_client/timing/__init__.py
+++ b/appenlight_client/timing/__init__.py
@@ -22,9 +22,9 @@ class AppenlightLocalStorage(object):
         stack = []
 
         for node in data:
-            node['parents'] = [n['type'] for n in stack]
             while stack and not self.contains(stack[-1], node):
                 stack.pop()
+            node['parents'] = [n['type'] for n in stack]
             stack.append(node)
         return data
 


### PR DESCRIPTION
If the start and end times don't overlap, the current stack is not a parent and should be popped.
Only when top of stack contains the current node then the stack's nodes should be added as parent nodes.