### PR TITLE
Fixed opening of source files on windows / django: added feature to ignore certain paths for slow reports / django: added feature to ignore certain paths

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,3 +41,4 @@ Contributors:
 * Lukasz Fidosz (virhilo) 2016-07-06
 * Lisa Quatmann (lisaq) 2016-03-06
 * Malthe Borch (malthe) 2013-02-18
+* Tomasz Utracki-Janeta (haloween) 2017-01-25

--- a/appenlight_client/client.py
+++ b/appenlight_client/client.py
@@ -186,6 +186,11 @@ class BaseClient(object):
                         self.config['timing'][k[18:]] = False
         self.hooks_blacklist = aslist(
             config.get('appenlight.hooks_blacklist'), ',')
+        self.config['ignore_slow_paths'] = \
+            config.get('appenlight.ignore_slow_paths', [])
+        self.config['ignore_paths'] = \
+            config.get('appenlight.ignore_paths', [])
+
 
     def reinitialize(self):
         self.filter_callable = lambda x: x

--- a/appenlight_client/django_middleware.py
+++ b/appenlight_client/django_middleware.py
@@ -73,7 +73,7 @@ class AppenlightMiddleware(MiddlewareMixin):
         
         if getattr(request, '_errormator_ignore_path', False):
             log.debug('ignore path in effect')
-            enabled = False
+            return None
 
         environ = request.environ
         if not self.appenlight_client.config['report_errors'] or environ.get('appenlight.ignore_error'):

--- a/appenlight_client/exceptions.py
+++ b/appenlight_client/exceptions.py
@@ -388,13 +388,15 @@ class Frame(object):
 
         if source is None:
             try:
-                f = open(self.filename)
-            except IOError:
+                with open(self.filename) as f:
+                    source = f.read()
+            except (IOError, OSError) as e:
                 return []
-            try:
-                source = f.read()
-            finally:
-                f.close()
+            except UnicodeDecodeError:
+                #since there's no io/os exception we can assume that the file exists
+                #so we will force it in utf-8
+                with open(self.filename, encoding='utf-8') as f:
+                    source = f.read()
 
         # already unicode?  return right away
         if isinstance(source, unicode):


### PR DESCRIPTION
When a file is open in Windows cp1250 encoding is used, that rises UnicodeDecodeError.
Reworked code should work as before, if a UnicodeDecodeError is risen we open the file in utf-8.

I've also added a feature in django middleware to allow ignoring of slow_log for certain paths (like /admin/) and second one for totally ignoring a path.

Settings responsible for those are:
- appenlight.ignore_slow_paths - [] - won't send slow report if path contains string present in list
- appenlight.ignore_paths - [] - won't send report AT ALL if path contains string present in list

Example django config:
APPENLIGHT = e_client.get_config({
    'appenlight.api_key':'***',
    'appenlight.ignore_slow_paths': ['/admin','/i_m_always_slow'],
    'appenlight.ignore_paths': ['/please_ingore_me','/and_me_too']
})
