### PR TITLE
Fixed windows traceback and added option to remove paths from error / slow reports

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,3 +41,4 @@ Contributors:
 * Lukasz Fidosz (virhilo) 2016-07-06
 * Lisa Quatmann (lisaq) 2016-03-06
 * Malthe Borch (malthe) 2013-02-18
+* Tomasz Utracki-Janeta (haloween) 2017-01-25

--- a/appenlight_client/client.py
+++ b/appenlight_client/client.py
@@ -186,6 +186,11 @@ class BaseClient(object):
                         self.config['timing'][k[18:]] = False
         self.hooks_blacklist = aslist(
             config.get('appenlight.hooks_blacklist'), ',')
+        self.config['ignore_slow_paths'] = \
+            config.get('appenlight.ignore_slow_paths', [])
+        self.config['ignore_paths'] = \
+            config.get('appenlight.ignore_paths', [])
+
 
     def reinitialize(self):
         self.filter_callable = lambda x: x

--- a/appenlight_client/django_middleware.py
+++ b/appenlight_client/django_middleware.py
@@ -33,11 +33,11 @@ class AppenlightMiddleware(MiddlewareMixin):
         request.__traceback__ = None
 
         if any(p in request.path for p in self.appenlight_client.config.get('ignore_slow_paths', [])):                
-            log.debug('ignore slow path in effect')
+            log.debug('ignore_slow_path in effect')
             environ['appenlight.ignore_slow'] = True
 
         if any(p in request.path for p in self.appenlight_client.config.get('ignore_paths', [])):
-            log.debug('ignore path in effect')
+            log.debug('ignore_path in effect')
             environ['appenlight.ignore_error'] = True
 
         environ = request.environ

--- a/appenlight_client/django_middleware.py
+++ b/appenlight_client/django_middleware.py
@@ -33,11 +33,11 @@ class AppenlightMiddleware(MiddlewareMixin):
         request.__traceback__ = None
 
         if any(p in request.path for p in self.appenlight_client.config.get('ignore_slow_paths', [])):                
-            log.debug('ignore_slow_path in effect')
+            log.debug('appenlight.ignore_slow_path in effect')
             environ['appenlight.ignore_slow'] = True
 
         if any(p in request.path for p in self.appenlight_client.config.get('ignore_paths', [])):
-            log.debug('ignore_path in effect')
+            log.debug('appenlight.ignore_path in effect')
             environ['appenlight.ignore_error'] = True
 
         environ = request.environ

--- a/appenlight_client/django_middleware.py
+++ b/appenlight_client/django_middleware.py
@@ -32,6 +32,8 @@ class AppenlightMiddleware(MiddlewareMixin):
         request._errormator_create_report = False
         request.__traceback__ = None
 
+        environ = request.environ
+
         if any(p in request.path for p in self.appenlight_client.config.get('ignore_slow_paths', [])):                
             log.debug('appenlight.ignore_slow_path in effect')
             environ['appenlight.ignore_slow'] = True
@@ -40,7 +42,6 @@ class AppenlightMiddleware(MiddlewareMixin):
             log.debug('appenlight.ignore_path in effect')
             environ['appenlight.ignore_error'] = True
 
-        environ = request.environ
         environ['appenlight.request_id'] = str(uuid.uuid4())
         # inject client instance reference to environ
         if 'appenlight.client' not in environ:

--- a/appenlight_client/django_middleware.py
+++ b/appenlight_client/django_middleware.py
@@ -73,7 +73,7 @@ class AppenlightMiddleware(MiddlewareMixin):
         
         if getattr(request, '_errormator_ignore_path', False):
             log.debug('ignore path in effect')
-            enabled = False
+            return None
 
         environ = request.environ
         if not self.appenlight_client.config['report_errors'] or environ.get('appenlight.ignore_error'):

--- a/appenlight_client/exceptions.py
+++ b/appenlight_client/exceptions.py
@@ -388,13 +388,15 @@ class Frame(object):
 
         if source is None:
             try:
-                f = open(self.filename)
-            except IOError:
+                with open(self.filename) as f:
+                    source = f.read()
+            except (IOError, OSError) as e:
                 return []
-            try:
-                source = f.read()
-            finally:
-                f.close()
+            except UnicodeDecodeError:
+                #since there's no io/os exception we can assume that the file exists
+                #so we will force it in utf-8
+                with open(self.filename, encoding='utf-8') as f:
+                    source = f.read()
 
         # already unicode?  return right away
         if isinstance(source, unicode):

--- a/appenlight_client/wsgi.py
+++ b/appenlight_client/wsgi.py
@@ -83,6 +83,15 @@ class AppenlightWSGIWrapper(object):
             stats, slow_calls = appenlight_storage.get_thread_stats()
             if 'appenlight.view_name' not in environ:
                 environ['appenlight.view_name'] = getattr(appenlight_storage, 'view_name', '')
+
+            if any(p in environ.get('PATH_INFO', '') for p in self.appenlight_client.config.get('ignore_slow_paths', [])):                
+                log.debug('ignore slow path in effect')
+                environ['appenlight.ignore_slow'] = True
+
+            if any(p in environ.get('PATH_INFO', '') for p in self.appenlight_client.config.get('ignore_paths', [])):
+                log.debug('ignore path in effect')
+                environ['appenlight.ignore_error'] = True
+
             if detected_data and detected_data[0]:
                 http_status = int(detected_data[0])
             if self.appenlight_client.config['slow_requests'] and not environ.get('appenlight.ignore_slow'):

--- a/appenlight_client/wsgi.py
+++ b/appenlight_client/wsgi.py
@@ -52,6 +52,14 @@ class AppenlightWSGIWrapper(object):
         if 'appenlight.extra' not in environ:
             environ['appenlight.extra'] = {}
 
+        if any(p in environ.get('PATH_INFO', '') for p in self.appenlight_client.config.get('ignore_slow_paths', [])):                
+            log.debug('appenlight.ignore_slow_path in effect')
+            environ['appenlight.ignore_slow'] = True
+
+        if any(p in environ.get('PATH_INFO', '') for p in self.appenlight_client.config.get('ignore_paths', [])):
+            log.debug('appenlight.ignore_path in effect')
+            environ['appenlight.ignore_error'] = True
+
         try:
             app_iter = self.app(environ, detect_headers)
             return app_iter
@@ -83,14 +91,6 @@ class AppenlightWSGIWrapper(object):
             stats, slow_calls = appenlight_storage.get_thread_stats()
             if 'appenlight.view_name' not in environ:
                 environ['appenlight.view_name'] = getattr(appenlight_storage, 'view_name', '')
-
-            if any(p in environ.get('PATH_INFO', '') for p in self.appenlight_client.config.get('ignore_slow_paths', [])):                
-                log.debug('appenlight.ignore_slow_path in effect')
-                environ['appenlight.ignore_slow'] = True
-
-            if any(p in environ.get('PATH_INFO', '') for p in self.appenlight_client.config.get('ignore_paths', [])):
-                log.debug('appenlight.ignore_path in effect')
-                environ['appenlight.ignore_error'] = True
 
             if detected_data and detected_data[0]:
                 http_status = int(detected_data[0])

--- a/appenlight_client/wsgi.py
+++ b/appenlight_client/wsgi.py
@@ -85,11 +85,11 @@ class AppenlightWSGIWrapper(object):
                 environ['appenlight.view_name'] = getattr(appenlight_storage, 'view_name', '')
 
             if any(p in environ.get('PATH_INFO', '') for p in self.appenlight_client.config.get('ignore_slow_paths', [])):                
-                log.debug('ignore_slow_path in effect')
+                log.debug('appenlight.ignore_slow_path in effect')
                 environ['appenlight.ignore_slow'] = True
 
             if any(p in environ.get('PATH_INFO', '') for p in self.appenlight_client.config.get('ignore_paths', [])):
-                log.debug('ignore_path in effect')
+                log.debug('appenlight.ignore_path in effect')
                 environ['appenlight.ignore_error'] = True
 
             if detected_data and detected_data[0]:

--- a/appenlight_client/wsgi.py
+++ b/appenlight_client/wsgi.py
@@ -92,6 +92,7 @@ class AppenlightWSGIWrapper(object):
             if 'appenlight.view_name' not in environ:
                 environ['appenlight.view_name'] = getattr(appenlight_storage, 'view_name', '')
 
+
             if detected_data and detected_data[0]:
                 http_status = int(detected_data[0])
             if self.appenlight_client.config['slow_requests'] and not environ.get('appenlight.ignore_slow'):

--- a/appenlight_client/wsgi.py
+++ b/appenlight_client/wsgi.py
@@ -85,11 +85,11 @@ class AppenlightWSGIWrapper(object):
                 environ['appenlight.view_name'] = getattr(appenlight_storage, 'view_name', '')
 
             if any(p in environ.get('PATH_INFO', '') for p in self.appenlight_client.config.get('ignore_slow_paths', [])):                
-                log.debug('ignore slow path in effect')
+                log.debug('ignore_slow_path in effect')
                 environ['appenlight.ignore_slow'] = True
 
             if any(p in environ.get('PATH_INFO', '') for p in self.appenlight_client.config.get('ignore_paths', [])):
-                log.debug('ignore path in effect')
+                log.debug('ignore_path in effect')
                 environ['appenlight.ignore_error'] = True
 
             if detected_data and detected_data[0]:


### PR DESCRIPTION
Fixed UnicodeDecodeError on Windows with cp1250 encoding (that happens in debug).

Added config option ignore_path and ignore_slow_path that allows exclusion of certain URLs from reporting. Fix is overridable in views.
