### PR TITLE
Fix log error message

### DIFF
--- a/appenlight_client/client.py
+++ b/appenlight_client/client.py
@@ -229,7 +229,7 @@ class BaseClient(object):
                 HTTPTransport as selected_transport
 
             msg = 'Could not import transport %s, using default, %s' % (
-                self.config['transport'], e)
+                self.config['transport'], str(selected_transport))
             log.error(msg)
 
         self.transport = selected_transport(self.config['transport_config'],


### PR DESCRIPTION
When transport configuration is not found, the code imports the default transport and log a error message with an e variable that not exists in the context.
Fixed to show the class string representation instead.

#49 related.