### PR TITLE
use a built in method to parse version strings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       env:
 
 install:
- - pip install flake8 rstcheck
+ - pip install flake8 rstcheck pyramid
 
 script:
   - python setup.py develop

--- a/AUTHORS
+++ b/AUTHORS
@@ -42,3 +42,4 @@ Contributors:
 * Lisa Quatmann (lisaq) 2016-03-06
 * Malthe Borch (malthe) 2013-02-18
 * Tomasz Utracki-Janeta (haloween) 2017-01-25
+* Joe Lombrozo (djeebus) 2019-04-18

--- a/appenlight_client/client.py
+++ b/appenlight_client/client.py
@@ -383,7 +383,7 @@ class BaseClient(object):
 
         for key, value in environ.items():
             if key.startswith('appenlight.') and key not in reserved_list:
-                appenlight_info[key[11:]] = unicode(value)
+                appenlight_info[key[11:]] = six.text_type(value)
             elif key == 'appenlight.tags':
                 appenlight_info['tags'] = []
                 for k, v in six.iteritems(value):
@@ -410,7 +410,7 @@ class BaseClient(object):
                             else:
                                 parsed_environ[key] = value.decode('utf8')
                         else:
-                            parsed_environ[key] = unicode(value)
+                            parsed_environ[key] = six.text_type(value)
                     except Exception:
                         pass
                         # provide better details for 500's
@@ -455,9 +455,9 @@ class BaseClient(object):
                         else:
                             try:
                                 parsed_environ['POST'][k] = [
-                                    unicode(val) for val in v]
+                                    six.text_type(val) for val in v]
                             except Exception:
-                                parsed_environ['POST'][k] = unicode(v)
+                                parsed_environ['POST'][k] = six.text_type(v)
                     except Exception as e:
                         pass
             except Exception as e:

--- a/appenlight_client/client.py
+++ b/appenlight_client/client.py
@@ -29,6 +29,7 @@ from __future__ import with_statement
 
 import datetime
 import logging
+import six
 import socket
 import uuid
 import os
@@ -385,14 +386,14 @@ class BaseClient(object):
                 appenlight_info[key[11:]] = unicode(value)
             elif key == 'appenlight.tags':
                 appenlight_info['tags'] = []
-                for k, v in value.iteritems():
+                for k, v in six.iteritems(value):
                     try:
                         appenlight_info['tags'].append(parse_tag(k, v))
                     except Exception as e:
                         log.info(u'Couldn\'t convert attached tag %s' % e)
             elif key == 'appenlight.extra':
                 appenlight_info['extra'] = []
-                for k, v in value.iteritems():
+                for k, v in six.iteritems(value):
                     try:
                         appenlight_info['extra'].append(parse_tag(k, v))
                     except Exception as e:

--- a/appenlight_client/django_middleware.py
+++ b/appenlight_client/django_middleware.py
@@ -1,3 +1,4 @@
+import six
 import uuid
 from datetime import datetime, timedelta
 from django.conf import settings
@@ -90,7 +91,7 @@ class AppenlightMiddleware(MiddlewareMixin):
         end_time = default_timer()
         if user and user_is_authenticated(user):
             if 'appenlight.username' not in environ:
-                environ['appenlight.username'] = unicode(user.pk)
+                environ['appenlight.username'] = six.text_type(user.pk)
         if not isinstance(exception, Http404):
             http_status = 500
             traceback = self.appenlight_client.get_current_traceback()
@@ -124,7 +125,7 @@ class AppenlightMiddleware(MiddlewareMixin):
                 http_status = response.status_code
                 if user and user_is_authenticated(user):
                     if 'appenlight.username' not in environ:
-                        environ['appenlight.username'] = unicode(user.pk)
+                        environ['appenlight.username'] = six.text_type(user.pk)
                 if (http_status == 404 and self.appenlight_client.config[
                     'report_404']):
                     request._errormator_create_report = True

--- a/appenlight_client/exceptions.py
+++ b/appenlight_client/exceptions.py
@@ -47,6 +47,7 @@ import re
 import os
 import inspect
 import itertools
+import six
 import traceback
 import codecs
 import collections
@@ -312,7 +313,7 @@ class Traceback(object):
                 if not isinstance(frame.locals, dict):
                     entry['vars'].append({'unknown': '<uninspectable>'})
                     continue
-                for k, v in frame.locals.iteritems():
+                for k, v in six.iteritems(frame.locals):
                     if id(v) not in id_list:
                         id_list.append(id(v))
                     else:

--- a/appenlight_client/exceptions.py
+++ b/appenlight_client/exceptions.py
@@ -77,7 +77,7 @@ _missing = _Missing()
 
 def truncate_str(input):
     try:
-        return unicode(input) if len(input) < 255 else unicode(input[:255]) + '...'
+        return six.text_type(input) if len(input) < 255 else six.text_type(input[:255]) + '...'
     except Exception:
         return '<failed-truncating>'
 
@@ -366,7 +366,7 @@ class Frame(object):
         info = self.locals.get('__traceback_info__')
         if info is not None:
             try:
-                info = unicode(info)
+                info = six.text_type(info)
             except UnicodeError:
                 info = str(info).decode('utf-8', 'replace')
         self.info = info

--- a/appenlight_client/ext/logging/logbook.py
+++ b/appenlight_client/ext/logging/logbook.py
@@ -69,7 +69,7 @@ def convert_record_to_dict(record, client_config):
                 try:
                     tags_list.append(parse_tag(k, v))
                     if k == 'ae_primary_key':
-                        log_dict['primary_key'] = unicode(v)
+                        log_dict['primary_key'] = six.text_type(v)
                     if k == 'ae_permanent':
                         try:
                             log_dict['permanent'] = asbool(v)

--- a/appenlight_client/ext/logging/logbook.py
+++ b/appenlight_client/ext/logging/logbook.py
@@ -64,7 +64,7 @@ def convert_record_to_dict(record, client_config):
         if client_config.get('logging_attach_exc_text'):
             pass
         # populate tags from extra
-        for k, v in record.extra.iteritems():
+        for k, v in six.iteritems(record.extra):
             if k not in EXCLUDED_LOG_VARS:
                 try:
                     tags_list.append(parse_tag(k, v))

--- a/appenlight_client/ext/logging/logger.py
+++ b/appenlight_client/ext/logging/logger.py
@@ -79,7 +79,7 @@ def convert_record_to_dict(record, client_config):
                 try:
                     tags_list.append(parse_tag(k, v))
                     if k == 'ae_primary_key':
-                        log_dict['primary_key'] = unicode(v)
+                        log_dict['primary_key'] = six.text_type(v)
                     if k == 'ae_permanent':
                         try:
                             log_dict['permanent'] = asbool(v)

--- a/appenlight_client/ext/logging/logger.py
+++ b/appenlight_client/ext/logging/logger.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import logging
 import datetime
+import six
 import time
 
 
@@ -73,7 +74,7 @@ def convert_record_to_dict(record, client_config):
             if exc_text:
                 log_dict['message'] += '\n%s' % exc_text
         # populate tags from extra
-        for k, v in vars(record).iteritems():
+        for k, v in six.iteritems(vars(record)):
             if k not in EXCLUDED_LOG_VARS:
                 try:
                     tags_list.append(parse_tag(k, v))

--- a/appenlight_client/tests.py
+++ b/appenlight_client/tests.py
@@ -2,6 +2,7 @@
 import copy
 import datetime
 import logging
+import six
 import socket
 import time
 import random
@@ -24,7 +25,7 @@ fname = pkg_resources.resource_filename('appenlight_client',
 timing_conf = client.get_config(path_to_config=fname)
 # set api key
 
-for k, v in timing_conf.iteritems():
+for k, v in six.iteritems(timing_conf):
     if 'appenlight.timing' in k:
         timing_conf[k] = 0.0000001
 
@@ -208,9 +209,8 @@ class TestClientConfig(BaseTest):
         self.setUpClient(config)
         superset = self.client.transport.transport_config.items()
         subset = {'url': 'https://api.appenlight.com', 'timeout': 10, 'threaded': 0}
-        for i in subset.iteritems():
+        for i in six.iteritems(subset):
             assert i in superset
-
 
     def test_enabled_client(self):
         self.setUpClient()
@@ -559,7 +559,7 @@ class TestErrorParsing(BaseTest):
                               start_time=REQ_START_TIME, end_time=REQ_END_TIME)
         subset = PARSED_REPORT_404
         superset = self.client.transport.report_queue[0].items()
-        for i in subset.iteritems():
+        for i in six.iteritems(subset):
             assert i in superset
 
     def test_py_report_500_no_traceback(self):
@@ -574,7 +574,7 @@ class TestErrorParsing(BaseTest):
         bogus_500_report['request_stats'] = {}
         subset = bogus_500_report
         superset = self.client.transport.report_queue[0].items()
-        for i in subset.iteritems():
+        for i in six.iteritems(subset):
             assert i in superset
 
 
@@ -598,7 +598,7 @@ class TestErrorParsing(BaseTest):
         bogus_report['traceback'][0]['line'] = line_no
         subset = bogus_report
         superset = self.client.transport.report_queue[0].items()
-        for i in subset.iteritems():
+        for i in six.iteritems(subset):
             assert i in superset
 
     def test_frameinfo(self):
@@ -870,7 +870,7 @@ class TestSlowReportParsing(BaseTest):
                               end_time=REQ_END_TIME)
         subset = PARSED_SLOW_REPORT
         superset = self.client.transport.report_queue[0].items()
-        for i in subset.iteritems():
+        for i in six.iteritems(subset):
             assert i in superset
 
 

--- a/appenlight_client/tests.py
+++ b/appenlight_client/tests.py
@@ -1684,6 +1684,27 @@ class TestCallableName(BaseTest):
                 assert row['parents'] == ['custom']
 
 
+class TestPyramidVersionParsing:
+    def _run_test(self, pyramid_version):
+        from appenlight_client.ext.pyramid_tween import can_pyramid_version_append_decorator
+        return can_pyramid_version_append_decorator(pyramid_version)
+
+    def test_pre_1_4_cannot(self):
+        assert self._run_test('1.3') is False
+
+    def test_early_1_4_cannot(self):
+        assert self._run_test('1.4a0') is False
+
+    def test_1_4_after_a4_can(self):
+        assert self._run_test('1.4a5') is True
+
+    def test_1_4_betas_can(self):
+        assert self._run_test('1.4b1') is True
+
+    def test_1_10_can(self):
+        assert self._run_test('1.10') is True
+
+
 
 if __name__ == '__main__':
     pass

--- a/appenlight_client/timing/__init__.py
+++ b/appenlight_client/timing/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import logging
+import six
 import time
 import threading
 
@@ -107,7 +108,7 @@ class AppenlightLocalStorage(object):
             if duration >= row['min_duration']:
                 slow_calls.append(row)
                 # round stats to 5 digits
-        for k, v in stats.iteritems():
+        for k, v in six.iteritems(stats):
             stats[k] = round(v, 5)
         return stats, slow_calls
 

--- a/appenlight_client/transports/__init__.py
+++ b/appenlight_client/transports/__init__.py
@@ -1,6 +1,7 @@
 import threading
 import datetime
 import logging
+import six
 
 log = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ class BaseTransport(object):
                                                                      'tmpl_calls': 0,
                                                                      'custom_calls': 0}
             self.request_stats[req_time][view_name]['requests'] += 1
-            for k, v in stats.iteritems():
+            for k, v in six.iteritems(stats):
                 self.request_stats[req_time][view_name][k] += v
 
     def check_if_deliver(self, force_send=False):
@@ -78,7 +79,7 @@ class BaseTransport(object):
             with self.request_stats_lock:
                 request_stats = self.request_stats
                 self.request_stats = {}
-            for k, v in request_stats.iteritems():
+            for k, v in six.iteritems(request_stats):
                 metrics.append({
                     "server": self.client_config['server_name'],
                     "metrics": v.items(),

--- a/appenlight_client/transports/requests.py
+++ b/appenlight_client/transports/requests.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import logging
 import requests
-import urlparse
+import six.moves.urllib.parse as urlparse
 import threading
 from appenlight_client.ext_json import json
 from appenlight_client.transports import BaseTransport

--- a/appenlight_client/utils.py
+++ b/appenlight_client/utils.py
@@ -2,6 +2,7 @@ import datetime
 import inspect
 import logging
 import os
+import six
 import sys
 import pkg_resources
 
@@ -12,7 +13,7 @@ log = logging.getLogger(__name__)
 
 
 def asbool(obj):
-    if isinstance(obj, (str, unicode)):
+    if isinstance(obj, six.string_types):
         obj = obj.strip().lower()
         if obj in ['true', 'y', 't', '1']:
             return True
@@ -25,7 +26,7 @@ def asbool(obj):
 
 
 def aslist(obj, sep=None, strip=True):
-    if isinstance(obj, basestring):
+    if isinstance(obj, six.string_types):
         lst = obj.split(sep)
         if strip:
             lst = [v.strip() for v in lst]

--- a/appenlight_client/utils.py
+++ b/appenlight_client/utils.py
@@ -136,7 +136,7 @@ def parse_tag(k, v):
     if isinstance(v, (basestring, datetime.datetime, datetime.date, float, int)):
         return (k, v,)
     else:
-        return (k, unicode(v),)
+        return (k, six.text_type(v),)
 
 
 class Version(object):


### PR DESCRIPTION
the old parsing doesn't work for pyramid 1.10+